### PR TITLE
Samtools version flexibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ ismap_bedtools.py
 ismap.txt
 slurm_ismap.txt
 compiledTables.pyc
+*.json

--- a/scripts/ismap.py
+++ b/scripts/ismap.py
@@ -38,23 +38,29 @@ except:
 
 class RunSamtools:
     def __init__(self):
+        # check iF SAMTOOLS environment variable exists, then use that command
+        try:
+            self.samtools_cmd = os.environ['SAMTOOLS']
+        except:
+            self.samtools_cmd = 'samtools'
         # check version:
-        p = Popen(['samtools'], stderr = PIPE)
+
+        p = Popen([self.samtools_cmd], stderr = PIPE)
         out,err = p.communicate()
         version_string = [l for l in err.decode('UTF-8').split('\n') if re.search('^Version', l)][0]
         if len(version_string) == 0:
             print("Could not find Samtools")
             raise IOError
         if len(re.findall('1\.[0-9]\.[0-9]', version_string)):
-            version_id=re.findall('1\.[0-9]\.[0-9]', version_string)[0]
+            version_id=re.findall('1\.[0-9]\.[0-9]{1,2}', version_string)[0]
             print("Found samtools version {}".format(version_id))
             self.version=1
         else:
-            version_id=re.findall('0\.[0-9]\.[0-9]', version_string)[0]
+            version_id=re.findall('0\.[0-9]\.[0-9]{1,2}', version_string)[0]
             print("Found samtools version {}".format(version_id))
             self.version=0
     def view(self, output_bam, input_sam, bigF=None, smallF=None):
-        cmd = 'samtools view -Sb'
+        cmd = self.samtools_cmd + ' view -Sb'
         if bigF !=None:
             cmd = cmd + ' -F {}'.format(bigF)
         if smallF != None:
@@ -62,7 +68,7 @@ class RunSamtools:
         cmd = cmd + ' -o {} {}'.format(output_bam, input_sam)
         return(shlex.split(cmd))
     def sort(self, output_bam, input_bam):
-        cmd = 'samtools sort'
+        cmd = self.samtools_cmd + ' sort'
         if self.version == 1:
             output_bam = output_bam + '.bam'
             cmd = cmd + ' -T tmp -o {} {}'.format(output_bam, input_bam)
@@ -70,7 +76,7 @@ class RunSamtools:
             cmd = cmd + ' {} {}'.format(input_bam, output_bam)
         return(shlex.split(cmd))
     def index(self, input_bam):
-        cmd = 'samtools index {}.bam'.format(input_bam)
+        cmd = self.samtools_cmd + ' index {}.bam'.format(input_bam)
         return(shlex.split(cmd))
 
 


### PR DESCRIPTION
Created a class to handle `samtools` commands from multiple `samtools` versions. It now works with `samtools 1.3.1`,`samtools 0.1.19`, and `samtools 0.1.18`.  But, have not verified that the results are equivalent across versions, just ensured it finished running. 

Also added the ability of specifying the exact `samtools` binary to use via an environment variable. For instance, to use `samtools 0.1.19` that is not in the `PATH`, just create the following environmental variable:

`export SAMTOOLS=/path/to/samtools_0.1.19/samtools`

Anders.
