### PR TITLE
added 'scripts/ismap.py' to the list of scripts to copy to /bin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author='Jane Hawkey',
     author_email='hawkey.jane@gmail.com',
     packages=['ismap'],
-    scripts=['scripts/binary_table.py', 'scripts/compiled_table.py', 'scripts/create_genbank_table.py',
+    scripts=['scripts/ismap.py', 'scripts/binary_table.py', 'scripts/compiled_table.py', 'scripts/create_genbank_table.py',
             'scripts/slurm_ismap.py', 'scripts/create_typing_out.py', 'scripts/slurm_ismap_sg.py'],
     entry_points={
         'console_scripts': ['ismap = ismap.ismap:main']


### PR DESCRIPTION
when installing this application in our cluster I noticed that script `ismap.py` is not copied to the `bin` folder in the installation directory. 

This small change in the `setup.py` file fixes it