### PR TITLE
set min_range and max_range args to be a float

### DIFF
--- a/scripts/ismap.py
+++ b/scripts/ismap.py
@@ -56,9 +56,9 @@ def parse_args():
                                  help='Minimum depth for mapped region to be kept in bed file (default 6)')
     parser_hits.add_argument('--novel_gap_size', type=int, required=False, default=15,
                              help='Distance in base pairs between left and right flanks to be called a novel hit (default 15)')
-    parser_hits.add_argument('--min_range', type=str, required=False, default=0.9,
+    parser_hits.add_argument('--min_range', type=float, required=False, default=0.9,
                                  help='Minimum percent size of the gap to be called a known hit (default 0.9, or 90 percent)')
-    parser_hits.add_argument('--max_range', type=str, required=False, default=1.1,
+    parser_hits.add_argument('--max_range', type=float, required=False, default=1.1,
                                  help='Maximum percent size of the gap to be called a known hit (default 1.1, or 110 percent)')
     parser_hits.add_argument('--merging', type=str, required=False, default='100',
                                  help='Value for merging left and right hits in bed files together to simply calculation of closest and intersecting regions (default 100).')


### PR DESCRIPTION
fixes bug in create_typing_output.py has multiple spots where min_range and max_range are being compared as a string instead of a float

Example: https://github.com/jhawkey/IS_mapper/blob/master/scripts/create_output.py#L389

Here's an example using the test data:
```
ismap --reads IS_mapper/test/inputs/ERR225612_*.fastq.gz \ 
           --queries IS_mapper/test/inputs/ISSsu3.fasta \
           --reference IS_mapper/test/inputs/S_suis_P17.gbk \
           --output_dir IS_mapper/test/ \
           --min_range 0.9 --max_range 1.1 --t 11
[M::bwa_idx_load_from_disk] read 0 ALT contigs
[M::process] read 733334 sequences (110000100 bp)...
[M::process] read 733334 sequences (110000100 bp)...
[M::mem_pestat] # candidate unique pairs for (FF, FR, RF, RR): (0, 0, 0, 0)
[M::mem_pestat] skip orientation FF as there are not enough pairs
[M::mem_pestat] skip orientation FR as there are not enough pairs
[M::mem_pestat] skip orientation RF as there are not enough pairs
[M::mem_pestat] skip orientation RR as there are not enough pairs
[M::mem_process_seqs] Processed 733334 reads in 60.621 CPU sec, 5.541 real sec
[M::process] read 568578 sequences (85286700 bp)...
[M::mem_pestat] # candidate unique pairs for (FF, FR, RF, RR): (1, 1278, 0, 0)
[M::mem_pestat] skip orientation FF as there are not enough pairs
[M::mem_pestat] analyzing insert size distribution for orientation FR...
[M::mem_pestat] (25, 50, 75) percentile: (316, 397, 484)
[M::mem_pestat] low and high boundaries for computing mean and std.dev: (1, 820)
[M::mem_pestat] mean and std.dev: (402.45, 119.04)
[M::mem_pestat] low and high boundaries for proper pairs: (1, 988)
[M::mem_pestat] skip orientation RF as there are not enough pairs
[M::mem_pestat] skip orientation RR as there are not enough pairs
[M::mem_process_seqs] Processed 733334 reads in 61.234 CPU sec, 5.399 real sec
[M::mem_pestat] # candidate unique pairs for (FF, FR, RF, RR): (0, 1, 0, 0)
[M::mem_pestat] skip orientation FF as there are not enough pairs
[M::mem_pestat] skip orientation FR as there are not enough pairs
[M::mem_pestat] skip orientation RF as there are not enough pairs
[M::mem_pestat] skip orientation RR as there are not enough pairs
[M::mem_process_seqs] Processed 568578 reads in 46.020 CPU sec, 4.171 real sec
[main] Version: 0.7.17-r1188
[main] CMD: bwa mem -t 11 IS_mapper/test/ERR225612/ISSsu3/tmp/ISSsu3.fasta IS_mapper/test/inputs/ERR225612_1.fastq.gz IS_mapper/test/inputs/ERR225612_2.fastq.gz
[main] Real time: 20.345 sec; CPU: 170.122 sec
[bwa_index] Pack FASTA... 0.02 sec
[bwa_index] Construct BWT for the packed sequence...
[bwa_index] 0.54 seconds elapse.
[bwa_index] Update BWT... 0.03 sec
[bwa_index] Pack forward-only FASTA... 0.01 sec
[bwa_index] Construct SA from BWT and Occ... 0.24 sec
[main] Version: 0.7.17-r1188
[main] CMD: bwa index IS_mapper/test/ERR225612/ISSsu3/tmp/AM946016.1.fasta
[main] Real time: 1.225 sec; CPU: 0.838 sec
[M::bwa_idx_load_from_disk] read 0 ALT contigs
[M::process] read 646 sequences (86294 bp)...
[M::mem_process_seqs] Processed 646 reads in 0.064 CPU sec, 0.007 real sec
[main] Version: 0.7.17-r1188
[main] CMD: bwa mem -t 11 IS_mapper/test/ERR225612/ISSsu3/tmp/AM946016.1.fasta IS_mapper/test/ERR225612/ISSsu3/ERR225612_ISSsu3_left_final.fastq
[main] Real time: 0.030 sec; CPU: 0.070 sec
[M::bwa_idx_load_from_disk] read 0 ALT contigs
[M::process] read 622 sequences (84177 bp)...
[M::mem_process_seqs] Processed 622 reads in 0.065 CPU sec, 0.007 real sec
[main] Version: 0.7.17-r1188
[main] CMD: bwa mem -t 11 IS_mapper/test/ERR225612/ISSsu3/tmp/AM946016.1.fasta IS_mapper/test/ERR225612/ISSsu3/ERR225612_ISSsu3_right_final.fastq
[main] Real time: 0.027 sec; CPU: 0.071 sec
Traceback (most recent call last):
  File "/home/rpetit/miniconda3/envs/ismapper_env/bin/ismap", line 12, in <module>
    sys.exit(main())
  File "/home/rpetit/miniconda3/envs/ismapper_env/bin/ismap.py", line 229, in main
    args.novel_gap_size, args.cds, args.rrna, args.trna, tmp_output_folder, sample.prefix)
  File "/home/rpetit/miniconda3/envs/ismapper_env/bin/create_output.py", line 685, in create_typing_output
    elif float(gap) / is_query_length >= min_range and float(gap) / is_query_length <= max_range:
TypeError: '>=' not supported between instances of 'float' and 'str'
```